### PR TITLE
added missing django-enum-choices dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ click-didyoumean==0.0.3
 click-repl==0.1.6
 Django==3.1.4
 django-celery-beat==2.1.0
+django-enum-choices==2.1.3
 django-timezone-field==4.1.1
 isort==5.6.4
 kombu==5.0.2


### PR DESCRIPTION
in /setups/models.py you do "from django_enum_choices.fields import EnumChoiceField" but you do not list the django-enum-choices library in requirements.txt